### PR TITLE
Pins ubuntu version for CI to Ubuntu 18.04

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ jobs:
   build:
   
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_run.yml
+++ b/.github/workflows/test_run.yml
@@ -10,7 +10,7 @@ jobs:
   build:
   
     name: Run testRun.sh
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Was seeing this issue with the latest ubuntu version

```
Error: 6.486 [error] Unable to load crypto library. Failed with error:
":load_failed, Failed to load NIF library /home/runner/work/_temp/.setup-elixir/otp/lib/crypto-4.9/priv/lib/crypto: 'libcrypto.so.1.0.0: cannot open shared object file: No such file or directory'"
OpenSSL might not be installed on this system.

```